### PR TITLE
Enabled ancestors in foxmlToSolr.xslt

### DIFF
--- a/foxmlToSolr.xslt
+++ b/foxmlToSolr.xslt
@@ -23,10 +23,9 @@
   xmlns:islandora-exts="xalan://ca.upei.roblib.DataStreamForXSLT"
             exclude-result-prefixes="exts"
   xmlns:encoder="xalan://java.net.URLEncoder"
-  xmlns:java="http://xml.apache.org/xalan/java">
-  <!--  Used for indexing other objects.
+  xmlns:java="http://xml.apache.org/xalan/java"
   xmlns:sparql="http://www.w3.org/2001/sw/DataAccess/rf1/result"
-  xmlns:xalan="http://xml.apache.org/xalan"> -->
+  xmlns:xalan="http://xml.apache.org/xalan">
 
   <xsl:output method="xml" indent="yes" encoding="UTF-8"/>
 

--- a/foxmlToSolr.xslt
+++ b/foxmlToSolr.xslt
@@ -264,18 +264,14 @@
         reindexing all the descendents whenever indexing an object
         (updating a collection label would be fairly expensive if we blindly
         reindexed). -->
-      <!--
       <xsl:variable name="ancestors">
         <xsl:call-template name="get-ancestors">
           <xsl:with-param name="PID" select="$PID" />
         </xsl:call-template>
       </xsl:variable>
-
       <xsl:for-each select="xalan:nodeset($ancestors)//sparql:obj[@uri != concat('info:fedora/', $PID)]">
         <field name="ancestors_ms"><xsl:value-of select="substring-after(@uri, '/')"/></field>
       </xsl:for-each>
-      -->
-
     </doc>
   </xsl:template>
 

--- a/foxmlToSolr.xslt
+++ b/foxmlToSolr.xslt
@@ -108,9 +108,9 @@
   <xsl:include href="/usr/local/fedora/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/MADS_to_solr.xslt"/>
   <xsl:include href="/usr/local/fedora/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/WORKFLOW_to_solr.xslt"/>
   <xsl:include href="/usr/local/fedora/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/slurp_all_chemicalML_to_solr.xslt"/>
-  <!--  Used for indexing other objects.
+  <!--  Used for indexing other objects.-->
   <xsl:include href="/usr/local/fedora/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/library/traverse-graph.xslt"/>
-  -->
+  
   <!-- Used to index the list of collections to which an object belongs.
     Requires the "traverse-graph.xslt" bit as well.
   <xsl:include href="/usr/local/fedora/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/hierarchy.xslt"/>

--- a/foxmlToSolr.xslt
+++ b/foxmlToSolr.xslt
@@ -112,10 +112,9 @@
   <xsl:include href="/usr/local/fedora/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/library/traverse-graph.xslt"/>
   
   <!-- Used to index the list of collections to which an object belongs.
-    Requires the "traverse-graph.xslt" bit as well.
+    Requires the "traverse-graph.xslt" bit as well.-->
   <xsl:include href="/usr/local/fedora/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/hierarchy.xslt"/>
-  -->
-
+  
   <!-- Decide which objects to modify the index of -->
   <xsl:template match="/">
     <update>


### PR DESCRIPTION
Jira ticket: https://discoverygarden.atlassian.net/browse/BPL-42

What does this pull request do?
Changes were made to the foxmlToSolr.xslt to show ancestors fields in solr. 

What's new?
Some includes fields were uncommented and the xsl variable for ancestors was also 
uncommented. 